### PR TITLE
Add ulm.freifunk.net to ssids

### DIFF
--- a/ssids.json
+++ b/ssids.json
@@ -153,6 +153,7 @@
 		"trier.freifunk.net",
 		"uelzen.freifunk.net",
 		"uelzen.freifunk.net (5GHz)",
+		"ulm.freifunk.net",
 		"westpfalz.freifunk.net",
 		"westpfalz.freifunk.net 5GHz",
 		"wiesbaden.freifunk.net",


### PR DESCRIPTION
Add SSID "ulm.freifunk.net" to list of ssids.
See: https://wiki.freifunk.net/Freifunk_Ulm#Freifunk_nutzen

Please review